### PR TITLE
Update to run on node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -78,6 +78,6 @@ inputs:
     default: 7
 
 runs:
-  using: node12
+  using: node16
   main: dist/main/index.js
   post: dist/post/index.js


### PR DESCRIPTION
GitHub is deprecating node12 and recommending all actions update.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/